### PR TITLE
让没有自带 fetch 函数的旧浏览器也能正常获取网页

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -346,14 +346,8 @@
 		"react/jsx-sort-props": 0,
 		"react/jsx-uses-react": 0,
 		"react/jsx-uses-vars": 1,
-		"react/no-did-mount-set-state": [
-			1,
-			"allow-in-func"
-		],
-		"react/no-did-update-set-state": [
-			1,
-			"allow-in-func"
-		],
+		"react/no-did-mount-set-state": 1,
+		"react/no-did-update-set-state": 1,
 		"react/no-multi-comp": 0,
 		"react/no-unknown-property": 0,
 		"react/prop-types": 0,

--- a/index.web.js
+++ b/index.web.js
@@ -1,4 +1,6 @@
 import 'babel-polyfill';
+import 'fetch-detector';
+import 'fetch-ie8';
 import {AppRegistry} from 'react-native';
 import Noder from './src';
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "push-key": "code-push deployment ls Noder -k"
   },
   "dependencies": {
+    "fetch-detector": "^1.0.0",
+    "fetch-ie8": "^1.4.3",
     "flux-standard-action": "^0.6.1",
     "lodash": "^4.13.1",
     "markdown": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "coffee-script": "^1.9.2",
     "dev-ip": "^1.0.1",
     "eslint": "^2.13.1",
-    "eslint-plugin-react": "^5.2.2",
+    "eslint-plugin-react": "^6.2.0",
     "file-loader": "^0.9.0",
     "gulp": "^3.9.1",
     "gulp-replace": "^0.5.4",


### PR DESCRIPTION
比如 Chrome 40 版本左右的，以及手机上的 UC 没有自带 fetch 函数。

现在则都能够正常获取网页了。